### PR TITLE
Add collection version to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,9 @@ assignees:
 ```
 
 ##### COLLECTION VERSION
-<!--- Paste verbatim output from "ansible-galaxy collection list | grep <collection>" (for example, community.general) between quotes -->
+<!--- Paste verbatim output from "ansible-galaxy collection list | grep <collection>"  between the quotes
+for example: ansible-galaxy collection list | grep community.general
+-->
 ```paste below
 
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,8 +27,8 @@ assignees:
 ```
 
 ##### COLLECTION VERSION
-<!--- Paste verbatim output from "ansible-galaxy collection list | grep <collection>"  between the quotes
-for example: ansible-galaxy collection list | grep community.general
+<!--- Paste verbatim output from "ansible-galaxy collection list <namespace>.<collection>"  between the quotes
+for example: ansible-galaxy collection list community.general
 -->
 ```paste below
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,6 +26,12 @@ assignees:
 
 ```
 
+##### COLLECTION VERSION
+<!--- Paste verbatim output from "ansible-galaxy collection list | grep <collection>" (for example, community.general) between quotes -->
+```paste below
+
+```
+
 ##### CONFIGURATION
 <!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
 ```paste below


### PR DESCRIPTION
##### SUMMARY
When someone opens an issue I often miss the information what version of the collection is used. The one that comes with ansible or a different version installed via galaxy? I think this question should be part of the template.

Fixes: ansible-community/community-topics#23

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
.github/ISSUE_TEMPLATE/bug_report.md

##### ADDITIONAL INFORMATION
context: ansible-community/community-topics#23