### PR TITLE
Update CODEOWNERS with generic details

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,5 @@
-* @ansible/ansible-commit
-.github/ @ansible/ansible-community
+# CODEOWNERS
+#
+# Defines people or teams that are responsible for code in a repository.
+# For more information, refer to the following documentation:
+# https://help.github.com/en/articles/about-code-owners


### PR DESCRIPTION
##### SUMMARY
Previous entries were not valid because the entries referenced teams in another GitHub org.

##### ISSUE TYPE
- Bugfix Pull Request